### PR TITLE
Install as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This package doesn't handle the communication with the API. Check out [notion-ap
 ### Vue
 
 ```bash
-npm install vue-notion
+npm install vue-notion --save-dev
 ```
 
 ### NuxtJS Module


### PR DESCRIPTION
In README, specify that the installation must be as devDependency, as recommended by [official docs](https://nuxtjs.org/docs/2.x/directory-structure/modules)(see buildModules section)