### PR TITLE
Renders inner NotionCallout content

### DIFF
--- a/src/blocks/callout.vue
+++ b/src/blocks/callout.vue
@@ -5,6 +5,7 @@
     </div>
     <div class="notion-callout-text">
       <NotionTextRenderer :text="title" v-bind="pass" />
+      <slot />
     </div>
   </div>
 </template>
@@ -19,7 +20,7 @@ export default {
   name: "NotionCallout",
   components: {
     NotionPageIcon,
-    NotionTextRenderer,
-  },
+    NotionTextRenderer
+  }
 };
 </script>

--- a/src/components/block.vue
+++ b/src/components/block.vue
@@ -14,7 +14,9 @@
     v-bind="pass"
   />
   <NotionBookmark v-else-if="isType('bookmark')" v-bind="pass" />
-  <NotionCallout v-else-if="isType('callout')" v-bind="pass" />
+  <NotionCallout v-else-if="isType('callout')" v-bind="pass">
+    <slot />
+  </NotionCallout>
   <NotionCode v-else-if="isType('code')" v-bind="pass" />
   <NotionEquation v-else-if="isType('equation')" v-bind="pass" />
   <NotionText v-else-if="isType('text')" v-bind="pass" />
@@ -102,13 +104,13 @@ export default {
     NotionTableRow,
     NotionText,
     NotionTodo,
-    NotionToggle,
+    NotionToggle
   },
   computed: {
     ...blockComputed,
     isRendererRegistered() {
       return "NotionRenderer" in Vue?.options?.components;
-    },
-  },
+    }
+  }
 };
 </script>


### PR DESCRIPTION
Hi @janniks hope you are doing good!

It looks like notion allows to include any kind of content within the Callout block. So you can have infinite nested content in them. I just opened a `<slot />` within the **NotionCallout** component so it keep rendering the blocks.

Now we are capable to render the following blockMap:

<img width="814" alt="Captura de pantalla 2022-04-11 a las 14 14 07" src="https://user-images.githubusercontent.com/13252924/162747334-e9f22e0a-c3a0-4a63-91c2-05590e91a2b0.png">

Thanks for your awesome block!