### PR TITLE
Add @babel/plugin-proposal-nullish-coalescing-operator to babel.confi…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,4 +2,7 @@ const devPresets = ['@vue/babel-preset-app'];
 const buildPresets = ['@babel/preset-env'];
 module.exports = {
   presets: (process.env.NODE_ENV === 'development' ? devPresets : buildPresets),
+  plugins: [
+    "@babel/plugin-proposal-nullish-coalescing-operator"
+  ],
 };


### PR DESCRIPTION
Hi Janniks,

I am a big fan of `vue-notion` and we're currently using it to show our documentation that is stored in Notion. However, I ran into a problem when I added `vue-notion` to a new repository that didn't have (and can't have) Webpack5. Webpack threw an error on the nullish coalescing operators. I created this small PR to make this repository run with Webpack4 as well, I would love to hear what you think about it.