### PR TITLE
Fix callouts with blocks as content

### DIFF
--- a/src/blocks/callout.vue
+++ b/src/blocks/callout.vue
@@ -21,7 +21,7 @@
 <script>
 import { Blockable } from "@/lib/blockable";
 import NotionPageIcon from "@/blocks/helpers/page-icon.vue";
-import NotionRenderer from "@/components/NotionRenderer.vue";
+import NotionRenderer from "@/components/notion-renderer.vue";
 import NotionTextRenderer from "@/blocks/helpers/text-renderer.vue";
 
 export default {

--- a/src/blocks/callout.vue
+++ b/src/blocks/callout.vue
@@ -4,7 +4,16 @@
       <NotionPageIcon v-bind="pass" />
     </div>
     <div class="notion-callout-text">
-      <NotionTextRenderer :text="title" v-bind="pass" />
+      <NotionRenderer
+        v-if="block.value.content"
+        v-for="(contentId, contentIndex) in block.value.content"
+        v-bind="pass"
+        :key="contentId"
+        :level="pass.level + 1"
+        :content-id="contentId"
+        :content-index="contentIndex"
+      />
+      <NotionTextRenderer v-else :text="title" v-bind="pass" />
     </div>
   </div>
 </template>
@@ -12,6 +21,7 @@
 <script>
 import { Blockable } from "@/lib/blockable";
 import NotionPageIcon from "@/blocks/helpers/page-icon.vue";
+import NotionRenderer from "@/components/NotionRenderer.vue";
 import NotionTextRenderer from "@/blocks/helpers/text-renderer.vue";
 
 export default {


### PR DESCRIPTION
This package has issue with callouts that use blocks as content instead of text. These callouts render empty.

I mentioned this issue here — https://github.com/janniks/vue-notion/issues/133

As issue is missing in vue3-notion, I investigated how @zernonia fixed that and added his fix.

Important: I just copied code from my fork, without any tests on your fork — so I think you need to test it before merging.

Also with my setup (it has a lot of stuff removed) I got into tricky circular reference bug. Fixed it here https://github.com/tough-dev-school/vue-notion/commit/47e13cb74efe7a9a4dad1aaa55247ec550ee081d. Add this fix if you need it.